### PR TITLE
fix: removed extra 55px padding from product details card

### DIFF
--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -4,7 +4,7 @@
  * File Created: Friday, 11th September 2020 10:18:53 am
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Friday, 11th September 2020 11:26:28 am
+ * Last Modified: Tuesday, 15th September 2020 4:30:08 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -39,7 +39,6 @@ type ProductDetailsProps = {
 const useStyles = makeStyles({
   root: {
     textAlign: 'center',
-    padding: '55px',
   },
   title: {
     width: '100%',


### PR DESCRIPTION
# Description
Se elimina padding incorrecto de 55px en la tarjeta de Product Details.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Storybook

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
