### PR TITLE
Feat/ehorn/modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:10:47 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 23rd September 2020 5:19:42 pm
+ * Last Modified: Thursday, 24th September 2020 2:16:19 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -26,7 +26,7 @@ import {
 
 type ModalProps = {
   open: boolean;
-  title?: string;
+  title: string;
   content: string;
   setOpen: (open: boolean) => void;
   actions?: ActionType[];
@@ -35,6 +35,7 @@ type ModalProps = {
 type ActionType = {
   text: string;
   onActionClick: () => void;
+  variant?: 'text' | 'outlined' | 'contained' | undefined;
 };
 
 const useStyles = makeStyles({
@@ -58,7 +59,12 @@ export function AlertModal(props: ModalProps) {
         </DialogContent>
         <DialogActions>
           {actions?.map((action: ActionType, index: number) => (
-            <Button key={index} onClick={action.onActionClick} color="primary">
+            <Button
+              key={index}
+              onClick={action.onActionClick}
+              color="primary"
+              variant={action.variant}
+            >
               {action.text}
             </Button>
           ))}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,65 @@
+/*
+ * File: Modal.tsx
+ * Project: @inventures/react-lib
+ * File Created: Wednesday, 23rd September 2020 4:10:47 pm
+ * Author: Esperanza Horn (esperanza@inventures.cl)
+ * -----
+ * Last Modified: Wednesday, 23rd September 2020 5:04:21 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
+ * -----
+ * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
+ * Terms and conditions defined in license.txt
+ * -----
+ * Inventures - www.inventures.cl
+ */
+
+import React, { useState } from 'react';
+import { createStyles, Theme } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+type ModalProps = {
+    open: boolean;
+    title ?: string;
+    content: string;
+    setOpen: (open: boolean) => void;
+    actions ?: ActionType[];
+};
+
+type ActionType = {
+    text: string;
+    onActionClick: () => void;
+};
+
+export function AlertModal(props: ModalProps) {
+    const { title, open, content, actions, setOpen } = props;
+
+    return (
+        <div>
+            <Dialog
+                open={open}
+                onClose={() => setOpen(false)}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+                <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                    {content}
+                </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    {actions?.map((action: ActionType, index: number) => (
+                        <Button onClick={action.onActionClick} color="primary">
+                            {action.text}
+                        </Button>
+                    ))}
+                </DialogActions>
+            </Dialog>
+        </div>
+    );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:10:47 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 23rd September 2020 5:12:43 pm
+ * Last Modified: Wednesday, 23rd September 2020 5:19:42 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -16,10 +16,13 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
+import {
+  DialogActions,
+  makeStyles,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core';
 
 type ModalProps = {
   open: boolean;
@@ -34,20 +37,22 @@ type ActionType = {
   onActionClick: () => void;
 };
 
+const useStyles = makeStyles({
+  contentText: {
+    textAlign: 'center',
+  },
+});
+
 export function AlertModal(props: ModalProps) {
   const { title, open, content, actions, setOpen } = props;
+  const classes = useStyles();
 
   return (
     <div>
-      <Dialog
-        open={open}
-        onClose={() => setOpen(false)}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle>{title}</DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-description">
+          <DialogContentText className={classes.contentText}>
             {content}
           </DialogContentText>
         </DialogContent>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:10:47 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 23rd September 2020 5:04:21 pm
+ * Last Modified: Wednesday, 23rd September 2020 5:12:43 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -13,8 +13,7 @@
  * Inventures - www.inventures.cl
  */
 
-import React, { useState } from 'react';
-import { createStyles, Theme } from '@material-ui/core/styles';
+import React from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -23,43 +22,43 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
 type ModalProps = {
-    open: boolean;
-    title ?: string;
-    content: string;
-    setOpen: (open: boolean) => void;
-    actions ?: ActionType[];
+  open: boolean;
+  title?: string;
+  content: string;
+  setOpen: (open: boolean) => void;
+  actions?: ActionType[];
 };
 
 type ActionType = {
-    text: string;
-    onActionClick: () => void;
+  text: string;
+  onActionClick: () => void;
 };
 
 export function AlertModal(props: ModalProps) {
-    const { title, open, content, actions, setOpen } = props;
+  const { title, open, content, actions, setOpen } = props;
 
-    return (
-        <div>
-            <Dialog
-                open={open}
-                onClose={() => setOpen(false)}
-                aria-labelledby="alert-dialog-title"
-                aria-describedby="alert-dialog-description"
-            >
-                <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
-                <DialogContent>
-                <DialogContentText id="alert-dialog-description">
-                    {content}
-                </DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                    {actions?.map((action: ActionType, index: number) => (
-                        <Button onClick={action.onActionClick} color="primary">
-                            {action.text}
-                        </Button>
-                    ))}
-                </DialogActions>
-            </Dialog>
-        </div>
-    );
+  return (
+    <div>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {content}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          {actions?.map((action: ActionType, index: number) => (
+            <Button key={index} onClick={action.onActionClick} color="primary">
+              {action.text}
+            </Button>
+          ))}
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,8 +4,8 @@
  * File Created: Friday, 31st July 2020 3:20:09 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Monday, 14th September 2020 1:19:59 pm
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Wednesday, 23rd September 2020 4:14:14 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -20,3 +20,4 @@ export * from './ImageLoader';
 export * from './ProductDetails';
 export * from './ProductList';
 export * from './ProductListHeader';
+export * from './Modal';

--- a/src/stories/5-Modal.stories.tsx
+++ b/src/stories/5-Modal.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:11:55 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 23rd September 2020 5:03:08 pm
+ * Last Modified: Wednesday, 23rd September 2020 5:10:59 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -13,39 +13,40 @@
  * Inventures - www.inventures.cl
  */
 
-import React, {useState} from 'react';
-import {
-  AlertModal
-} from '../components';
+import React, { useState } from 'react';
+import { AlertModal } from '../components';
 import Button from '@material-ui/core/Button';
-import { text, number } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 
 export default {
   title: 'Modal',
 };
 
 export const CustomModal = () => {
-    const [open, setOpen] = useState(false);
-    const titleText = text('titleText', 'Validación receta');
-    const contentText = text('contentText', '¡Gracias! Nuestros químicos farmacéuticos van a verificar que todo esté en orden 👨🏻‍⚕️👩🏻‍⚕️ Te avisaremos si hay algún problema');
+  const [open, setOpen] = useState(false);
+  const titleText = text('titleText', 'Validación receta');
+  const contentText = text(
+    'contentText',
+    '¡Gracias! Nuestros químicos farmacéuticos van a verificar que todo esté en orden 👨🏻‍⚕️👩🏻‍⚕️ Te avisaremos si hay algún problema',
+  );
 
-    return (
-        <>
-            <Button variant="outlined" color="primary" onClick={() => setOpen(true)}>
-                Open alert dialog
-            </Button>
-            <AlertModal
-                title={titleText}
-                content={contentText}
-                open={open}
-                setOpen={setOpen}
-                actions={[
-                    {
-                        text: 'OK',
-                        onActionClick: () => setOpen(false),
-                    }
-                ]}
-            />
-        </>
-    );
+  return (
+    <>
+      <Button variant="outlined" color="primary" onClick={() => setOpen(true)}>
+        Open alert dialog
+      </Button>
+      <AlertModal
+        title={titleText}
+        content={contentText}
+        open={open}
+        setOpen={setOpen}
+        actions={[
+          {
+            text: 'OK',
+            onActionClick: () => setOpen(false),
+          },
+        ]}
+      />
+    </>
+  );
 };

--- a/src/stories/5-Modal.stories.tsx
+++ b/src/stories/5-Modal.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:11:55 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 23rd September 2020 5:10:59 pm
+ * Last Modified: Wednesday, 23rd September 2020 5:29:02 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -43,6 +43,14 @@ export const CustomModal = () => {
         actions={[
           {
             text: 'OK',
+            onActionClick: () => setOpen(false),
+          },
+          {
+            text: 'Aceptar',
+            onActionClick: () => setOpen(false),
+          },
+          {
+            text: 'Cerrar',
             onActionClick: () => setOpen(false),
           },
         ]}

--- a/src/stories/5-Modal.stories.tsx
+++ b/src/stories/5-Modal.stories.tsx
@@ -1,0 +1,51 @@
+/*
+ * File: 5-Modal.stories.tsx
+ * Project: @inventures/react-lib
+ * File Created: Wednesday, 23rd September 2020 4:11:55 pm
+ * Author: Esperanza Horn (esperanza@inventures.cl)
+ * -----
+ * Last Modified: Wednesday, 23rd September 2020 5:03:08 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
+ * -----
+ * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
+ * Terms and conditions defined in license.txt
+ * -----
+ * Inventures - www.inventures.cl
+ */
+
+import React, {useState} from 'react';
+import {
+  AlertModal
+} from '../components';
+import Button from '@material-ui/core/Button';
+import { text, number } from '@storybook/addon-knobs';
+
+export default {
+  title: 'Modal',
+};
+
+export const CustomModal = () => {
+    const [open, setOpen] = useState(false);
+    const titleText = text('titleText', 'Validación receta');
+    const contentText = text('contentText', '¡Gracias! Nuestros químicos farmacéuticos van a verificar que todo esté en orden 👨🏻‍⚕️👩🏻‍⚕️ Te avisaremos si hay algún problema');
+
+    return (
+        <>
+            <Button variant="outlined" color="primary" onClick={() => setOpen(true)}>
+                Open alert dialog
+            </Button>
+            <AlertModal
+                title={titleText}
+                content={contentText}
+                open={open}
+                setOpen={setOpen}
+                actions={[
+                    {
+                        text: 'OK',
+                        onActionClick: () => setOpen(false),
+                    }
+                ]}
+            />
+        </>
+    );
+};

--- a/src/stories/5-Modal.stories.tsx
+++ b/src/stories/5-Modal.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:11:55 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 23rd September 2020 5:29:02 pm
+ * Last Modified: Thursday, 24th September 2020 2:16:31 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -44,10 +44,12 @@ export const CustomModal = () => {
           {
             text: 'OK',
             onActionClick: () => setOpen(false),
+            variant: 'contained',
           },
           {
             text: 'Aceptar',
             onActionClick: () => setOpen(false),
+            variant: 'outlined',
           },
           {
             text: 'Cerrar',


### PR DESCRIPTION
# Description
Se crea componente modal reutilizable. El estado open/close del modal y su función de seteo respectiva deben ser manejados por el componente padre que lo contenga. AlertModal recibe, por lo tanto, las props obligatorias `open` y `setOpen`.

## Type of change
- [x] New component (non-breaking change which adds component)
- [ ] Documentation

## How Has This Been Tested?
- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)
![Custom Modal](https://user-images.githubusercontent.com/26127375/94065374-744de980-fdc1-11ea-889c-8cdad81534e2.PNG)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
