### PR TITLE
fix: lenght validator now can recieve only min or only max values

### DIFF
--- a/src/stories/1-Input.stories.tsx
+++ b/src/stories/1-Input.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 8th July 2020 1:55:18 am
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Friday, 4th September 2020 4:44:12 pm
+ * Last Modified: Tuesday, 29th September 2020 2:54:15 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -43,6 +43,38 @@ export type CountryType = {
 };
 
 export const Base = () => <Input />;
+
+export const LengthValidatorTest = () => {
+  const validLength = text(
+    'RUT de largo inválido error',
+    'Recuerda incluir un largo válido',
+  );
+
+  const debounceTime = number('Debounce time (ms)', 800);
+  const [value, setValue, status, errors, handleBlur] = useInput('', {
+    validators: [
+      validLength && new LengthValidator(validLength, { max: 11 }),
+    ].filter(Boolean) as Validator<string>[],
+    debounceTime,
+  });
+  const handleWrite = useCallback(
+    (e) => {
+      setValue(String(e.target.value));
+    },
+    [setValue],
+  );
+  return (
+    <Input
+      value={value}
+      onChange={handleWrite}
+      onBlur={handleBlur}
+      error={status === InputStatus.ERROR}
+      helperText={errors[0]}
+      label="Enter your text"
+    />
+  );
+};
+
 export const InputForRut = () => {
   const required = text('RUT requerido error', 'RUT Requerido');
   const incomplete = text(

--- a/src/validators/LengthValidator.ts
+++ b/src/validators/LengthValidator.ts
@@ -4,8 +4,8 @@
  * File Created: Friday, 14th August 2020 3:09:48 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 9th September 2020 11:37:58 am
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Tuesday, 29th September 2020 2:39:09 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -17,8 +17,12 @@ import { Validator } from './Validator';
 
 type LengthType =
   | {
-      min: number;
+      min?: number;
       max: number;
+    }
+  | {
+      min: number;
+      max?: number;
     }
   | number;
 
@@ -32,8 +36,10 @@ export class LengthValidator extends Validator {
       this.requiredLength = length;
       return;
     }
-    this.minLength = length.min;
-    this.maxLength = length.max;
+    this.minLength = length.min ? length.min : -Infinity;
+    this.maxLength = length.max ? length.max : Infinity;
+    //this.minLength = length.min;
+    //this.maxLength = length.max;
   }
 
   validate(input: string) {


### PR DESCRIPTION
# Description
Se adapta el tipado de los params de LengthValidator para poder recibir solamente min o solamente max. En ese caso, el param faltante se asigna como -Infinity o Infinity respectivamente. 
Se agrega también un ejemplo en la story de input, para poder probarlo.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Storybook
- [ ] Unit testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
