### PR TITLE
fix: thousand separator fix when below 4 digits

### DIFF
--- a/src/formatters/CurrencyFormatter.ts
+++ b/src/formatters/CurrencyFormatter.ts
@@ -17,11 +17,13 @@ import { Formatter } from './Formatter';
 
 export class CurrencyFormatter extends Formatter {
   format(input: number) {
-    const formatter = new Intl.NumberFormat('es-CL', {
+    const formatter = new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: 'CLP',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
     });
     const formattedText = formatter.format(input);
-    return formattedText;
+    return formattedText.replace(',', '.');
   }
 }


### PR DESCRIPTION
# Description

When the number under the currency formatter had below 4 digits it did not include the '.' separator. It is a problem with any currency that uses dots instead of commas when separating the number. Now it's fixed using the dollar currency but with no decimals and replacing the commas for dots

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Storybook

### Screenshots (Only if need)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
