### PR TITLE
feat: Image loader initial and Modal break line

### DIFF
--- a/src/components/ImageLoader.tsx
+++ b/src/components/ImageLoader.tsx
@@ -44,13 +44,14 @@ const useStyles = makeStyles({
   marginLeftZero: {
     marginLeft: '0!important',
   },
+  preview: {
+    objectFit: 'contain',
+  },
 });
 
 //Type
 type ImageLoaderProps = {
   types?: string[];
-  alt?: string;
-  objectFit?: string;
   maxFileSize?: number;
 
   Placeholder?: React.ReactNode;
@@ -67,8 +68,6 @@ type ImageLoaderProps = {
 
 export default function ImageLoader({
   types = [],
-  alt,
-  objectFit = 'contain',
   maxFileSize = 14,
   Placeholder = null,
   onError = () => {},
@@ -83,25 +82,7 @@ export default function ImageLoader({
 }: ImageLoaderProps) {
   const classes = useStyles();
   const iframeRef: React.RefObject<HTMLIFrameElement> = React.createRef();
-
   const inputRef: React.RefObject<HTMLInputElement> = React.createRef();
-
-  //Update objectfit
-  React.useLayoutEffect(() => {
-    //Waiting for iframe's content reendering
-    setTimeout(function () {
-      const iframe = iframeRef.current;
-      if (iframe && iframe.contentDocument) {
-        const imgs = iframe.contentDocument.getElementsByTagName('img');
-        if (imgs.length) {
-          imgs[0].style.objectFit = objectFit ? objectFit : 'contain';
-          imgs[0].alt = alt ? alt : 'Default';
-          imgs[0].style.width = '100%';
-          imgs[0].style.height = '100%';
-        }
-      }
-    }, 100);
-  }, [objectFit, iframeRef, alt]);
 
   const loadFile = React.useCallback(
     (event: React.BaseSyntheticEvent) => {
@@ -147,9 +128,8 @@ export default function ImageLoader({
   }, [setFile, setLoaded, inputRef]);
 
   const onCardActionAreaClick = React.useCallback(() => {
-    const input = inputRef.current;
-    input?.click();
-  }, [inputRef]);
+    inputRef.current?.click();
+  }, []);
 
   return (
     <div className={clsx(classes.container, classes.totallyFilled)}>
@@ -162,31 +142,37 @@ export default function ImageLoader({
           }
           onClick={onCardActionAreaClick}
         >
-          {!loaded && !loading ? (
+          {!file && !loading ? (
             Placeholder
           ) : (
-            <iframe
-              title="Contenedor"
-              ref={iframeRef}
-              src={file}
-              className={
-                loading
-                  ? clsx(classes.loading, classes.totallyFilled)
-                  : clsx(classes.container, classes.totallyFilled)
-              }
-            ></iframe>
+            <>
+              <object
+                data={file}
+                type="image/png"
+                className={clsx(
+                  classes.totallyFilled,
+                  { [classes.loading]: loading, [classes.container]: !loading },
+                  classes.preview,
+                )}
+                title="Contenedor"
+                ref={iframeRef}
+                src={file}
+              >
+                <embed src={file} type="image/png" />
+              </object>
+
+              {/* <iframe
+                
+              ></iframe> */}
+            </>
           )}
         </CardActionArea>
 
-        {loading ? (
-          <LinearProgress variant="determinate" value={progress} />
-        ) : (
-          ''
-        )}
+        {loading && <LinearProgress variant="determinate" value={progress} />}
         <Divider />
 
         <CardActions className={classes.actions}>
-          {loaded ? (
+          {loaded && (
             <IconButton
               color="primary"
               aria-label="Eliminar elemento"
@@ -196,8 +182,6 @@ export default function ImageLoader({
             >
               <DeleteIcon />
             </IconButton>
-          ) : (
-            ''
           )}
           <input
             ref={inputRef}

--- a/src/components/ImageLoader.tsx
+++ b/src/components/ImageLoader.tsx
@@ -155,8 +155,6 @@ export default function ImageLoader({
                   classes.preview,
                 )}
                 title="Contenedor"
-                ref={iframeRef}
-                src={file}
               >
                 <embed src={file} type="image/png" />
               </object>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,8 +4,8 @@
  * File Created: Wednesday, 23rd September 2020 4:10:47 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Thursday, 24th September 2020 2:16:19 pm
- * Modified By: Esperanza Horn (esperanza@inventures.cl)
+ * Last Modified: Friday, 9th October 2020 10:41:16 am
+ * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -41,13 +41,14 @@ type ActionType = {
 const useStyles = makeStyles({
   contentText: {
     textAlign: 'center',
+    whiteSpace: 'pre-line',
   },
 });
 
 export function AlertModal(props: ModalProps) {
   const { title, open, content, actions, setOpen } = props;
   const classes = useStyles();
-
+  console.log({ content });
   return (
     <div>
       <Dialog open={open} onClose={() => setOpen(false)}>

--- a/src/stories/4-imageloeader.stories.tsx
+++ b/src/stories/4-imageloeader.stories.tsx
@@ -65,7 +65,7 @@ const Placeholder = ({
 };
 export const LandscapeEditable = () => {
   const types = ['application/pdf', 'text/plain', 'image/jpeg', 'image/png'];
-  const objectFit = text('Object fit', 'contain');
+
   const defaultImage = text(
     'Default image',
     'https://previews.123rf.com/images/creativepriyanka/creativepriyanka1906/creativepriyanka190600379/124982633-prescription-icon.jpg',
@@ -103,7 +103,7 @@ export const LandscapeEditable = () => {
 
 export const PortraitEditable = () => {
   const types = ['application/pdf', 'text/plain', 'image/jpeg', 'image/png'];
-  const objectFit = text('Object fit', 'contain');
+
   const defaultImage = text(
     'Default image',
     'https://previews.123rf.com/images/creativepriyanka/creativepriyanka1906/creativepriyanka190600379/124982633-prescription-icon.jpg',
@@ -147,8 +147,7 @@ export const Landscape = () => {
   const [progress, setProgress] = useState(0);
 
   const types = ['application/pdf', 'text/plain', 'image/jpeg', 'image/png'];
-  const alt = text('Name', 'Medicamento');
-  const objectFit = text('Object fit', 'contain');
+
   const maxFileSize = number('Max size', 14);
   const defaultImage = text(
     'Default image',
@@ -214,8 +213,7 @@ export const Portrait = () => {
   const [progress, setProgress] = useState(0);
 
   const types = ['application/pdf', 'text/plain', 'image/jpeg', 'image/png'];
-  const alt = text('Name', 'Medicamento');
-  const objectFit = text('Object fit', 'contain');
+
   const maxFileSize = number('Max size', 14);
   const defaultImage = text(
     'Default image',
@@ -270,6 +268,75 @@ export const Portrait = () => {
         loaded={loaded}
         setLoaded={setLoaded}
       ></ImageLoader>
+    </div>
+  );
+};
+
+export const DefaultImageUploaded = () => {
+  const [file, setFile] = useState(
+    'https://meki-public.s3.us-east-2.amazonaws.com/images/1-paleta-desechable-0a9ea08b-088c-49c1-900a-84946978ad35',
+  );
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const types = ['application/pdf', 'text/plain', 'image/jpeg', 'image/png'];
+
+  const maxFileSize = number('Max size', 14);
+  const defaultImage = text(
+    'Default image',
+    'https://previews.123rf.com/images/creativepriyanka/creativepriyanka1906/creativepriyanka190600379/124982633-prescription-icon.jpg',
+  );
+
+  const defaultTitle = text('Default title', 'Adjunta tu receta aquí');
+  const defaultDescription = text(
+    'Default description',
+    'Puedes subir una imagen o PDF ',
+  );
+  const compressImage = async (file: File) => {
+    const options = {
+      maxSizeMB: maxFileSize,
+      useWebWorker: true,
+      onProgress: (progress: number) => {
+        setProgress(progress);
+      },
+    };
+
+    try {
+      //Compression
+      const compressedFile = await imageCompression(file, options);
+      setLoaded(true);
+      setLoading(false);
+    } catch (error) {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ width: '300px', height: '400px' }}>
+      <ImageLoader
+        types={types}
+        alt={alt}
+        objectFit={objectFit}
+        maxFileSize={maxFileSize}
+        Placeholder={
+          <Placeholder
+            defaultImage={defaultImage}
+            title={defaultTitle}
+            description={defaultDescription}
+          />
+        }
+        onError={onError}
+        compressImage={compressImage}
+        file={file}
+        setFile={setFile}
+        loading={loading}
+        setLoading={setLoading}
+        progress={progress}
+        loaded={loaded}
+        setLoaded={setLoaded}
+      ></ImageLoader>
+      <img src="https://meki-public.s3.us-east-2.amazonaws.com/images/accessories-by-lima-safiro-e0e10d66-37b2-4eda-9f07-11787ddb8c88" />
     </div>
   );
 };

--- a/src/stories/4-imageloeader.stories.tsx
+++ b/src/stories/4-imageloeader.stories.tsx
@@ -82,7 +82,6 @@ export const LandscapeEditable = () => {
     <div style={{ width: '400px', height: '300px' }}>
       <ImageLoader
         types={types}
-        objectFit={objectFit}
         Placeholder={
           <Placeholder
             defaultImage={defaultImage}
@@ -121,7 +120,6 @@ export const PortraitEditable = () => {
     <div style={{ width: '300px', height: '400px' }}>
       <ImageLoader
         types={types}
-        objectFit={objectFit}
         Placeholder={
           <Placeholder
             defaultImage={defaultImage}
@@ -182,8 +180,6 @@ export const Landscape = () => {
     <div style={{ width: '400px', height: '300px' }}>
       <ImageLoader
         types={types}
-        alt={alt}
-        objectFit={objectFit}
         maxFileSize={maxFileSize}
         Placeholder={
           <Placeholder
@@ -248,8 +244,6 @@ export const Portrait = () => {
     <div style={{ width: '300px', height: '400px' }}>
       <ImageLoader
         types={types}
-        alt={alt}
-        objectFit={objectFit}
         maxFileSize={maxFileSize}
         Placeholder={
           <Placeholder
@@ -316,8 +310,6 @@ export const DefaultImageUploaded = () => {
     <div style={{ width: '300px', height: '400px' }}>
       <ImageLoader
         types={types}
-        alt={alt}
-        objectFit={objectFit}
         maxFileSize={maxFileSize}
         Placeholder={
           <Placeholder
@@ -336,7 +328,6 @@ export const DefaultImageUploaded = () => {
         loaded={loaded}
         setLoaded={setLoaded}
       ></ImageLoader>
-      <img src="https://meki-public.s3.us-east-2.amazonaws.com/images/accessories-by-lima-safiro-e0e10d66-37b2-4eda-9f07-11787ddb8c88" />
     </div>
   );
 };


### PR DESCRIPTION
# Description

Use object and embed instead iframe for image loader preview. This support default data and transform application/octet-stream to image (from aws display)
Also, add break line support to modal content

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New component (non-breaking change which adds component)
- [ ] New hook (non-breaking change which adds hook)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (repo config)
- [ ] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
