### PR TITLE
modal margin from 32px to 16px

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -43,6 +43,9 @@ const useStyles = makeStyles({
     textAlign: 'center',
     whiteSpace: 'pre-line',
   },
+  margin: {
+    margin: 16,
+  },
 });
 
 export function AlertModal(props: ModalProps) {
@@ -51,7 +54,11 @@ export function AlertModal(props: ModalProps) {
   console.log({ content });
   return (
     <div>
-      <Dialog open={open} onClose={() => setOpen(false)}>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        PaperProps={{ className: classes.margin }}
+      >
         <DialogTitle>{title}</DialogTitle>
         <DialogContent>
           <DialogContentText className={classes.contentText}>


### PR DESCRIPTION
# Description

Changed the default margin of Dialog from 32px to 16px so the titles can fit completly in the width of the component.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New component (non-breaking change which adds component)
- [ ] New hook (non-breaking change which adds hook)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (repo config)
- [ ] Documentation

## How Has This Been Tested?

- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
