### PR TITLE
fix: search bar is now open when component is focused

### DIFF
--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 1st September 2020 9:46:25 am
  * Author: Luis Aparicio (luis@inventures.cl)
  * -----
- * Last Modified: Friday, 25th September 2020 2:29:15 pm
+ * Last Modified: Thursday, 29th October 2020 2:13:56 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -86,7 +86,7 @@ export const SearchBar = ({
     barColor: barColor,
   });
   const [showIcon, setShowIcon] = useState<boolean>(false);
-  const [showInputField, setshowInputField] = useState<boolean>(false);
+  const [showInputField, setshowInputField] = useState<boolean>(true);
 
   const handleInputChange = useCallback(() => {
     setshowInputField((prev) => !prev);


### PR DESCRIPTION
# Description
Fixes original SearchBar component `showInputField` to be true instead of false when component first mounts. This makes the SearchBar to be open when the component is focused.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Storybook - Local Chrome test
- [ ] Unit testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
