### PR TITLE
feat: disabled prop for CartProduct

### DIFF
--- a/src/components/CartProduct.tsx
+++ b/src/components/CartProduct.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import { TextFieldProps } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
@@ -16,7 +16,7 @@ import Icon from '@material-ui/core/Icon';
 import { useToast } from '../hooks/toast.hook';
 import { CurrencyFormatter } from '../formatters';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
   },
@@ -60,7 +60,10 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
   },
-});
+  activeIcon: {
+    color: theme.palette.text.primary,
+  },
+}));
 
 //Type
 type CartProductProps = {
@@ -72,6 +75,7 @@ type CartProductProps = {
   quantity?: number;
   unitPrice: number;
   totalPrice: number;
+  disabled?: boolean;
   ExtraTag?: React.ReactNode;
   onDefaultClick?: () => void;
   onAddClick?: () => void;
@@ -91,6 +95,7 @@ export default function CartProduct({
   unitPrice,
   totalPrice,
   ExtraTag = null,
+  disabled,
   onDefaultClick = () => {},
   onAddClick = () => {},
   onSubClick = () => {},
@@ -167,9 +172,14 @@ export default function CartProduct({
           <IconButton
             aria-label="sub"
             onClick={onSubClick}
+            disabled={disabled}
             className={classes.subbutton}
           >
-            <Icon color="primary" fontSize="small">
+            <Icon
+              className={disabled ? '' : classes.activeIcon}
+              color={disabled ? 'disabled' : 'inherit'}
+              fontSize="small"
+            >
               remove
             </Icon>
           </IconButton>
@@ -181,9 +191,14 @@ export default function CartProduct({
           <IconButton
             aria-label="add"
             onClick={onAddClick}
+            disabled={disabled}
             className={classes.addbutton}
           >
-            <Icon color="primary" fontSize="small">
+            <Icon
+              className={disabled ? '' : classes.activeIcon}
+              color={disabled ? 'disabled' : 'inherit'}
+              fontSize="small"
+            >
               add
             </Icon>
           </IconButton>
@@ -192,9 +207,14 @@ export default function CartProduct({
             className={classes.trashicon}
             aria-label="delete"
             onClick={onTrashClick}
+            disabled={disabled}
             size="small"
           >
-            <DeleteIcon fontSize="small" />
+            <DeleteIcon
+              fontSize="small"
+              className={disabled ? '' : classes.activeIcon}
+              color={disabled ? 'disabled' : 'inherit'}
+            />
           </IconButton>
         </Box>
       </CardActions>


### PR DESCRIPTION
# Description

Addd the 'disabled' prop in CartProduct in order to disable the add/sub/trash buttons and change the color of the icons from textPrimary to disabled

## Type of change

Please delete options that are not relevant.

- [x] add feat to component (non-breaking change which adds a feature to a component)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
