### PR TITLE
fix: calendar in spanish and monday is first day

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -4,8 +4,8 @@
  * File Created: Friday, 25th September 2020 3:06:54 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Thursday, 15th October 2020 6:09:58 pm
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Thursday, 10th November 2020 3:02:58 pm
+ * Modified By: Vicente Melin (vicente@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -14,6 +14,7 @@
  */
 
 import 'date-fns';
+import esLocale from 'date-fns/locale/es';
 import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import {
@@ -35,7 +36,7 @@ export function Calendar(props: CustomCalendarProps) {
   };
 
   return (
-    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+    <MuiPickersUtilsProvider utils={DateFnsUtils} locale={esLocale}>
       <DatePicker
         disableToolbar
         format="dd/MM/yyyy"
@@ -43,6 +44,7 @@ export function Calendar(props: CustomCalendarProps) {
         id="date-picker-inline"
         value={selectedDate}
         minDateMessage="La fecha es anterior al minimo"
+        cancelLabel="Cancelar"
         {...datePickerprops}
         onChange={handleDateChange}
       />


### PR DESCRIPTION
# Description

Change the language and the first day displayed in the Calendar component. It used to be in english and with the first day of the week on sunday. With this fix it's now in spanish and with the first day on monday.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New component (non-breaking change which adds component)
- [ ] New hook (non-breaking change which adds hook)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (repo config)
- [ ] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
