### PR TITLE
feat: added customizable badges to Product Cards

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -4,7 +4,7 @@
  * File Created: Monday, 31st August 2020 3:33:49 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Tuesday, 10th November 2020 4:09:20 pm
+ * Last Modified: Tuesday, 10th November 2020 4:17:16 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -110,8 +110,6 @@ export function ProductCard(props: ProductPropTypes) {
     badgeTextColor,
     onClickCard,
   } = props;
-
-  console.log(props);
 
   const currFormat = new CurrencyFormatter();
   const currencyPrice = currFormat.format(price);

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -4,7 +4,7 @@
  * File Created: Monday, 31st August 2020 3:33:49 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Monday, 9th November 2020 6:29:07 pm
+ * Last Modified: Tuesday, 10th November 2020 4:09:20 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -37,8 +37,14 @@ export type ProductPropTypes = {
   details?: string;
   badgeContent?: number;
   badgeColor?: string;
+  badgeTextColor?: string;
   price: number;
   onClickCard: () => void;
+};
+
+type BadgeStyleProps = {
+  badgeColor: string;
+  badgeTextColor: string;
 };
 
 const useStyles = makeStyles({
@@ -62,7 +68,7 @@ const useStyles = makeStyles({
     objectFit: 'contain',
   },
   tag: {
-    marginTop: '-14px',
+    //marginTop: '-14px',
     maxWidth: '100%',
     zIndex: 999,
   },
@@ -73,10 +79,11 @@ const useStyles = makeStyles({
     marginTop: '8px',
   },
   badge: {
-    //top: '16px',
-    //right: '-168px',
-    //position: 'relative',
-    zIndex: 0,
+    backgroundColor: (props: BadgeStyleProps) => props.badgeColor,
+    right: 16,
+    top: 16,
+    color: (props: BadgeStyleProps) => props.badgeTextColor,
+    padding: '0px 4px',
   },
 });
 
@@ -99,88 +106,91 @@ export function ProductCard(props: ProductPropTypes) {
     description,
     details,
     badgeContent,
+    badgeColor,
+    badgeTextColor,
     onClickCard,
   } = props;
 
+  console.log(props);
+
   const currFormat = new CurrencyFormatter();
   const currencyPrice = currFormat.format(price);
-  const classes = useStyles();
+  const classes = useStyles({
+    badgeColor: badgeColor ? badgeColor : '#000000',
+    badgeTextColor: badgeTextColor ? badgeTextColor : '#FFFFFF',
+  });
 
   return (
     <>
-    <Card className={classes.root}>
-      <CardActionArea>
-          {badgeContent? (
-          <Badge 
-            badgeContent={badgeContent} 
-            color="secondary" 
-            className={classes.badge} 
-            max={9}
-            overlap="circle"
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'right',
-            }}
-          >
+      <Card className={classes.root}>
+        <CardActionArea>
+          {badgeContent ? (
+            <Badge
+              badgeContent={badgeContent}
+              max={9}
+              classes={{
+                badge: classes.badge,
+              }}
+            >
+              <CardMedia
+                className={classes.media}
+                image={imageUrl}
+                onClick={onClickCard}
+                component="img"
+              />
+            </Badge>
+          ) : (
             <CardMedia
               className={classes.media}
               image={imageUrl}
               onClick={onClickCard}
               component="img"
             />
-          </Badge>
-        ) : (
-          <CardMedia
-            className={classes.media}
-            image={imageUrl}
-            onClick={onClickCard}
-            component="img"
-          />
-        )}
-        
-        <Chip
-          color="primary"
-          size="small"
-          icon={tagIcon}
-          label={tagText}
-          className={clsx(classes.tag, !tagText && classes.disabledTag)}
-        />
+          )}
 
-        <CardContent className={classes.content} onClick={onClickCard}>
-          <Typography
-            variant="subtitle1"
-            color="textPrimary"
-            className={classes.title}
-            noWrap
-          >
-            {title}
-          </Typography>
-          {subtitle && (
-            <Typography variant="body2" color="textSecondary" noWrap>
-              {subtitle}
-            </Typography>
-          )}
-          {description && (
-            <Typography variant="body2" color="textPrimary" noWrap>
-              {description}
-            </Typography>
-          )}
-          {details && (
-            <Typography variant="body2" color="textSecondary" noWrap>
-              {details}
-            </Typography>
-          )}
-          <Typography
-            variant="h6"
+          <Chip
             color="primary"
-            className={classes.price}
-            noWrap
-          >
-            {currencyPrice}
-          </Typography>
-        </CardContent>
-      </CardActionArea>
-    </Card>
+            size="small"
+            icon={tagIcon}
+            label={tagText}
+            className={clsx(classes.tag, !tagText && classes.disabledTag)}
+          />
+
+          <CardContent className={classes.content} onClick={onClickCard}>
+            <Typography
+              variant="subtitle1"
+              color="textPrimary"
+              className={classes.title}
+              noWrap
+            >
+              {title}
+            </Typography>
+            {subtitle && (
+              <Typography variant="body2" color="textSecondary" noWrap>
+                {subtitle}
+              </Typography>
+            )}
+            {description && (
+              <Typography variant="body2" color="textPrimary" noWrap>
+                {description}
+              </Typography>
+            )}
+            {details && (
+              <Typography variant="body2" color="textSecondary" noWrap>
+                {details}
+              </Typography>
+            )}
+            <Typography
+              variant="h6"
+              color="primary"
+              className={classes.price}
+              noWrap
+            >
+              {currencyPrice}
+            </Typography>
+          </CardContent>
+        </CardActionArea>
+      </Card>
     </>
   );
 }

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -4,7 +4,7 @@
  * File Created: Monday, 31st August 2020 3:33:49 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Friday, 11th September 2020 11:26:34 am
+ * Last Modified: Monday, 9th November 2020 6:29:07 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -22,6 +22,7 @@ import {
   CardContent,
   Typography,
   Chip,
+  Badge,
 } from '@material-ui/core';
 import { CurrencyFormatter } from '../formatters';
 import clsx from 'clsx';
@@ -34,6 +35,8 @@ export type ProductPropTypes = {
   tagIcon?: React.ReactElement;
   description?: string;
   details?: string;
+  badgeContent?: number;
+  badgeColor?: string;
   price: number;
   onClickCard: () => void;
 };
@@ -61,12 +64,19 @@ const useStyles = makeStyles({
   tag: {
     marginTop: '-14px',
     maxWidth: '100%',
+    zIndex: 999,
   },
   disabledTag: {
     backgroundColor: '#FFFFFF',
   },
   price: {
     marginTop: '8px',
+  },
+  badge: {
+    //top: '16px',
+    //right: '-168px',
+    //position: 'relative',
+    zIndex: 0,
   },
 });
 
@@ -88,6 +98,7 @@ export function ProductCard(props: ProductPropTypes) {
     price,
     description,
     details,
+    badgeContent,
     onClickCard,
   } = props;
 
@@ -96,14 +107,37 @@ export function ProductCard(props: ProductPropTypes) {
   const classes = useStyles();
 
   return (
+    <>
     <Card className={classes.root}>
       <CardActionArea>
-        <CardMedia
-          className={classes.media}
-          image={imageUrl}
-          onClick={onClickCard}
-          component="img"
-        />
+          {badgeContent? (
+          <Badge 
+            badgeContent={badgeContent} 
+            color="secondary" 
+            className={classes.badge} 
+            max={9}
+            overlap="circle"
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+          >
+            <CardMedia
+              className={classes.media}
+              image={imageUrl}
+              onClick={onClickCard}
+              component="img"
+            />
+          </Badge>
+        ) : (
+          <CardMedia
+            className={classes.media}
+            image={imageUrl}
+            onClick={onClickCard}
+            component="img"
+          />
+        )}
+        
         <Chip
           color="primary"
           size="small"
@@ -147,5 +181,6 @@ export function ProductCard(props: ProductPropTypes) {
         </CardContent>
       </CardActionArea>
     </Card>
+    </>
   );
 }

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -4,7 +4,7 @@
  * File Created: Friday, 11th September 2020 10:18:24 am
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Friday, 11th September 2020 11:27:46 am
+ * Last Modified: Monday, 9th November 2020 6:03:28 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -131,6 +131,8 @@ export function ProductList(props: ProductList) {
             tagText={cardInfo.tagText}
             tagIcon={cardInfo.tagIcon}
             onClickCard={cardInfo.onClickCard}
+            badgeContent={cardInfo.badgeContent}
+            badgeColor={cardInfo.badgeColor}
           />
         </Grid>
       ))}

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -4,7 +4,7 @@
  * File Created: Friday, 11th September 2020 10:18:24 am
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Monday, 9th November 2020 6:03:28 pm
+ * Last Modified: Tuesday, 10th November 2020 4:15:42 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -133,6 +133,7 @@ export function ProductList(props: ProductList) {
             onClickCard={cardInfo.onClickCard}
             badgeContent={cardInfo.badgeContent}
             badgeColor={cardInfo.badgeColor}
+            badgeTextColor={cardInfo.badgeTextColor}
           />
         </Grid>
       ))}

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Friday, 11th September 2020 10:13:32 am
+ * Last Modified: Monday, 9th November 2020 6:31:25 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -77,12 +77,13 @@ export const ProductCarousel = () => {
         products={[
           {
             imageUrl:
-              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+              'https://static.emol.cl/emol50/Fotos/2015/08/13/file_20150813131739.jpg',
             title: 'Glafornillafornillafornillafornillafornillafornil',
             subtitle: 'Metformina Clorhidrato Clorhidrato',
             price: 15990,
             tagText: 'Receta retenida',
             tagIcon: <InsertDriveFileOutlinedIcon />,
+            badgeContent: 4,
             onClickCard: () => console.log('You clicked B1!'),
           },
           {
@@ -93,6 +94,7 @@ export const ProductCarousel = () => {
             details: '30 comprimidos recubiertos',
             description: '500 mg',
             price: 15990,
+            badgeContent: 5,
             onClickCard: () => console.log('You clicked B2!'),
           },
           {
@@ -114,6 +116,7 @@ export const ProductCarousel = () => {
             details: '30 comprimidos recubiertos',
             description: '500 mg',
             price: 15990,
+            badgeContent: 10,
             onClickCard: () => console.log('You clicked B2!'),
           },
           {

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Monday, 9th November 2020 6:31:25 pm
+ * Last Modified: Tuesday, 10th November 2020 4:10:24 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -77,13 +77,15 @@ export const ProductCarousel = () => {
         products={[
           {
             imageUrl:
-              'https://static.emol.cl/emol50/Fotos/2015/08/13/file_20150813131739.jpg',
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
             title: 'Glafornillafornillafornillafornillafornillafornil',
             subtitle: 'Metformina Clorhidrato Clorhidrato',
             price: 15990,
             tagText: 'Receta retenida',
             tagIcon: <InsertDriveFileOutlinedIcon />,
-            badgeContent: 4,
+            badgeContent: 5,
+            badgeColor: 'red',
+            badgeTextColor: '#FFFFFF',
             onClickCard: () => console.log('You clicked B1!'),
           },
           {
@@ -95,6 +97,8 @@ export const ProductCarousel = () => {
             description: '500 mg',
             price: 15990,
             badgeContent: 5,
+            badgeColor: 'red',
+            badgeTextColor: '#FFFFFF',
             onClickCard: () => console.log('You clicked B2!'),
           },
           {
@@ -116,42 +120,47 @@ export const ProductCarousel = () => {
             details: '30 comprimidos recubiertos',
             description: '500 mg',
             price: 15990,
+            badgeContent: 5,
+            badgeColor: 'red',
+            badgeTextColor: '#FFFFFF',
+            onClickCard: () => console.log('You clicked B2!'),
+          },
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            tagText: 'Receta retenida',
+            tagIcon: <InsertDriveFileOutlinedIcon />,
+            onClickCard: () => console.log('You clicked B3!'),
+          },
+
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            onClickCard: () => console.log('You clicked B2!'),
+          },
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            tagText: 'Receta retenida',
+            tagIcon: <InsertDriveFileOutlinedIcon />,
             badgeContent: 10,
-            onClickCard: () => console.log('You clicked B2!'),
-          },
-          {
-            imageUrl:
-              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
-            title: 'Glafornil',
-            subtitle: 'Metformina Clorhidrato Clorhidrato',
-            details: '30 comprimidos recubiertos',
-            description: '500 mg',
-            price: 15990,
-            tagText: 'Receta retenida',
-            tagIcon: <InsertDriveFileOutlinedIcon />,
-            onClickCard: () => console.log('You clicked B3!'),
-          },
-
-          {
-            imageUrl:
-              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
-            title: 'Glafornil',
-            subtitle: 'Metformina Clorhidrato Clorhidrato',
-            details: '30 comprimidos recubiertos',
-            description: '500 mg',
-            price: 15990,
-            onClickCard: () => console.log('You clicked B2!'),
-          },
-          {
-            imageUrl:
-              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
-            title: 'Glafornil',
-            subtitle: 'Metformina Clorhidrato Clorhidrato',
-            details: '30 comprimidos recubiertos',
-            description: '500 mg',
-            price: 15990,
-            tagText: 'Receta retenida',
-            tagIcon: <InsertDriveFileOutlinedIcon />,
+            badgeColor: 'blue',
+            badgeTextColor: 'white',
             onClickCard: () => console.log('You clicked B3!'),
           },
         ]}

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Tuesday, 10th November 2020 4:10:24 pm
+ * Last Modified: Tuesday, 10th November 2020 4:17:10 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED


### PR DESCRIPTION
# Description
Product Cards now include an optional Material UI Badge that shows the product quantity in the cart. The badge color, content and text color are customizable. 

## Type of change
- [x] New component (non-breaking change which adds component)

## How Has This Been Tested?
- [x] Storybook

### Screenshots (Only if need)
![image](https://user-images.githubusercontent.com/26127375/98723310-f47bde80-2370-11eb-864e-cfcbff6165a0.png)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
