### PR TITLE
fix: supports optional modal for image updates

### DIFF
--- a/src/components/ImageLoader.tsx
+++ b/src/components/ImageLoader.tsx
@@ -195,7 +195,6 @@ function ImageLoaderComponent(
           className={classes.input}
           onChange={loadFile}
           disabled={loading}
-          //onClick={onClick}
         />
         <CardActions className={classes.actions}>
           {loaded && (
@@ -224,9 +223,6 @@ function ImageLoaderComponent(
   );
 }
 
-// Replace this line with the code below:
+// Forward Ref:
 const ImageLoader = React.forwardRef(ImageLoaderComponent);
-/* const ImageLoader = React.forwardRef((props, ref) => {
-  return <ImageLoaderComponent {...props} ref={ref}/>;
-}); */
 export default ImageLoader;

--- a/src/components/ImageLoader.tsx
+++ b/src/components/ImageLoader.tsx
@@ -63,7 +63,7 @@ type ImageLoaderProps = {
   progress?: number;
   loaded?: boolean;
   setLoaded?: (loaded: boolean) => void;
-  setOpenModal?: (open: boolean) => void;
+  handleCustomClick?: () => void;
 } & TextFieldProps;
 
 function ImageLoaderComponent(
@@ -80,7 +80,7 @@ function ImageLoaderComponent(
     progress,
     loaded,
     setLoaded = () => {},
-    setOpenModal,
+    handleCustomClick,
   }: ImageLoaderProps,
   ref: any,
 ) {
@@ -136,25 +136,9 @@ function ImageLoaderComponent(
     if (input) input.value = '';
   }, [setFile, setLoaded, inputRef]);
 
-  const onCardActionAreaClick = React.useCallback(() => {
-    if (loaded && setOpenModal) {
-      console.log('OPEN MODAL!!');
-      setOpenModal(true);
-      return;
-    } else {
-      inputRef.current?.click();
-    }
-  }, [setOpenModal, loaded]);
-
-  const onClickCamera = React.useCallback(() => {
-    if (loaded && setOpenModal) {
-      console.log('OPEN MODAL!!');
-      setOpenModal(true);
-      return;
-    } else {
-      inputRef.current?.click();
-    }
-  }, [setOpenModal, loaded]);
+  const onClick = React.useCallback(() => {
+    inputRef.current?.click();
+  }, []);
 
   console.log('loaded: ', loaded);
 
@@ -167,7 +151,7 @@ function ImageLoaderComponent(
               ? clsx(classes.cardactionarea, classes.loadingHeight)
               : clsx(classes.cardactionarea, classes.notloadingHeight)
           }
-          onClick={onCardActionAreaClick}
+          onClick={handleCustomClick ? handleCustomClick : onClick}
         >
           {!file && !loading ? (
             Placeholder
@@ -203,7 +187,16 @@ function ImageLoaderComponent(
 
         {loading && <LinearProgress variant="determinate" value={progress} />}
         <Divider />
-
+        <input
+          ref={inputRef}
+          id="icon-button-file"
+          type="file"
+          accept="image/*;capture=camera"
+          className={classes.input}
+          onChange={loadFile}
+          disabled={loading}
+          //onClick={onClick}
+        />
         <CardActions className={classes.actions}>
           {loaded && (
             <IconButton
@@ -216,26 +209,15 @@ function ImageLoaderComponent(
               <DeleteIcon />
             </IconButton>
           )}
-          <input
-            ref={loaded && setOpenModal ? null : inputRef}
-            id="icon-button-file"
-            type="file"
-            accept="image/*;capture=camera"
-            className={classes.input}
-            onChange={loadFile}
+          <IconButton
+            color="primary"
+            aria-label="Subir elemento"
+            component="span"
             disabled={loading}
-            onClick={onClickCamera}
-          />
-          <label htmlFor="icon-button-file" className={classes.marginLeftZero}>
-            <IconButton
-              color="primary"
-              aria-label="Subir elemento"
-              component="span"
-              disabled={loading}
-            >
-              <PhotoCamera />
-            </IconButton>
-          </label>
+            onClick={handleCustomClick ? handleCustomClick : onClick}
+          >
+            <PhotoCamera />
+          </IconButton>
         </CardActions>
       </Card>
     </div>

--- a/src/components/ImageLoader.tsx
+++ b/src/components/ImageLoader.tsx
@@ -53,7 +53,6 @@ const useStyles = makeStyles({
 type ImageLoaderProps = {
   types?: string[];
   maxFileSize?: number;
-
   Placeholder?: React.ReactNode;
   onError?: () => void;
   compressImage?: (file: File) => void;
@@ -64,6 +63,7 @@ type ImageLoaderProps = {
   progress?: number;
   loaded?: boolean;
   setLoaded?: (loaded: boolean) => void;
+  setOpenModal?: (open: boolean) => void;
 } & TextFieldProps;
 
 function ImageLoaderComponent(
@@ -80,16 +80,19 @@ function ImageLoaderComponent(
     progress,
     loaded,
     setLoaded = () => {},
+    setOpenModal,
   }: ImageLoaderProps,
   ref: any,
 ) {
   const classes = useStyles();
   const inputRef = React.useRef(ref);
+
   React.useImperativeHandle(ref, () => ({
     click: () => {
       inputRef.current?.click();
     },
   }));
+
   const loadFile = React.useCallback(
     (event: React.BaseSyntheticEvent) => {
       const divisor = 1024 * 1024;
@@ -125,15 +128,35 @@ function ImageLoaderComponent(
       types,
     ],
   );
+
   const deleteFile = React.useCallback(() => {
     setFile('');
     setLoaded(false);
     const input = inputRef.current;
     if (input) input.value = '';
   }, [setFile, setLoaded, inputRef]);
+
   const onCardActionAreaClick = React.useCallback(() => {
-    inputRef.current?.click();
-  }, []);
+    if (loaded && setOpenModal) {
+      console.log('OPEN MODAL!!');
+      setOpenModal(true);
+      return;
+    } else {
+      inputRef.current?.click();
+    }
+  }, [setOpenModal, loaded]);
+
+  const onClickCamera = React.useCallback(() => {
+    if (loaded && setOpenModal) {
+      console.log('OPEN MODAL!!');
+      setOpenModal(true);
+      return;
+    } else {
+      inputRef.current?.click();
+    }
+  }, [setOpenModal, loaded]);
+
+  console.log('loaded: ', loaded);
 
   return (
     <div className={clsx(classes.container, classes.totallyFilled)}>
@@ -160,7 +183,19 @@ function ImageLoaderComponent(
                 )}
                 title="Contenedor"
               >
-                <embed src={file} type="image/png" />
+                <object
+                  data={file}
+                  type="application/pdf"
+                  className={clsx(
+                    classes.totallyFilled,
+                    {
+                      [classes.loading]: loading,
+                      [classes.container]: !loading,
+                    },
+                    classes.preview,
+                  )}
+                  title="Contenedor"
+                ></object>
               </object>
             </>
           )}
@@ -182,13 +217,14 @@ function ImageLoaderComponent(
             </IconButton>
           )}
           <input
-            ref={inputRef}
+            ref={loaded && setOpenModal ? null : inputRef}
             id="icon-button-file"
             type="file"
             accept="image/*;capture=camera"
             className={classes.input}
             onChange={loadFile}
             disabled={loading}
+            onClick={onClickCamera}
           />
           <label htmlFor="icon-button-file" className={classes.marginLeftZero}>
             <IconButton
@@ -206,5 +242,9 @@ function ImageLoaderComponent(
   );
 }
 
+// Replace this line with the code below:
 const ImageLoader = React.forwardRef(ImageLoaderComponent);
+/* const ImageLoader = React.forwardRef((props, ref) => {
+  return <ImageLoaderComponent {...props} ref={ref}/>;
+}); */
 export default ImageLoader;

--- a/src/components/ImageLoader.tsx
+++ b/src/components/ImageLoader.tsx
@@ -140,8 +140,6 @@ function ImageLoaderComponent(
     inputRef.current?.click();
   }, []);
 
-  console.log('loaded: ', loaded);
-
   return (
     <div className={clsx(classes.container, classes.totallyFilled)}>
       <Card className={clsx(classes.container, classes.totallyFilled)}>

--- a/src/stories/4-imageloeader.stories.tsx
+++ b/src/stories/4-imageloeader.stories.tsx
@@ -399,6 +399,15 @@ export const UploaderWithModal = () => {
     setOpen(false);
   }, [openFileLoader, setOpen]);
 
+  const handleCustomClick = React.useCallback(() => {
+    if (loaded) {
+      console.log('OPEN MODAL!!');
+      setOpen(true);
+    } else {
+      inputRef.current?.click();
+    }
+  }, [loaded, setOpen]);
+
   console.log('open: ', open);
   return (
     <>
@@ -423,7 +432,7 @@ export const UploaderWithModal = () => {
           loaded={loaded}
           setLoaded={setLoaded}
           ref={inputRef}
-          setOpenModal={setOpen}
+          handleCustomClick={handleCustomClick}
         />
       </div>
       <AlertModal

--- a/src/stories/4-imageloeader.stories.tsx
+++ b/src/stories/4-imageloeader.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ImageLoader from '../components/ImageLoader';
+import { AlertModal } from '../components/Modal';
 import { text, number, boolean } from '@storybook/addon-knobs';
 import imageCompression from 'browser-image-compression';
 import Button from '@material-ui/core/Button';
@@ -236,6 +237,7 @@ export const Portrait = () => {
     try {
       //Compression
       const compressedFile = await imageCompression(file, options);
+      console.log(compressedFile);
       setLoaded(true);
       setLoading(false);
     } catch (error) {
@@ -341,5 +343,106 @@ export const DefaultImageUploaded = () => {
         </Button>
       </Box>
     </div>
+  );
+};
+
+export const UploaderWithModal = () => {
+  const [file, setFile] = useState(
+    'https://meki-public.s3.us-east-2.amazonaws.com/images/1-paleta-desechable-0a9ea08b-088c-49c1-900a-84946978ad35',
+  );
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  const types = ['application/pdf', 'text/plain', 'image/jpeg', 'image/png'];
+
+  const maxFileSize = number('Max size', 14);
+  const defaultImage = text(
+    'Default image',
+    'https://previews.123rf.com/images/creativepriyanka/creativepriyanka1906/creativepriyanka190600379/124982633-prescription-icon.jpg',
+  );
+
+  const defaultTitle = text('Default title', 'Adjunta tu receta aquí');
+  const defaultDescription = text(
+    'Default description',
+    'Puedes subir una imagen o PDF ',
+  );
+  const compressImage = async (file: File) => {
+    const options = {
+      maxSizeMB: maxFileSize,
+      useWebWorker: true,
+      onProgress: (progress: number) => {
+        setProgress(progress);
+      },
+    };
+
+    try {
+      //Compression
+      const compressedFile = await imageCompression(file, options);
+      setLoaded(true);
+      setLoading(false);
+    } catch (error) {
+      setLoading(false);
+    }
+  };
+
+  const inputRef = React.createRef<HTMLInputElement | undefined>();
+
+  const openFileLoader = React.useCallback(() => {
+    inputRef.current?.click();
+  }, [inputRef]);
+
+  const clickYesModal = React.useCallback(() => {
+    console.log('You clicked YES');
+    openFileLoader();
+    setOpen(false);
+  }, [openFileLoader, setOpen]);
+
+  console.log('open: ', open);
+  return (
+    <>
+      <div style={{ width: '300px', height: '400px' }}>
+        <ImageLoader
+          types={types}
+          maxFileSize={maxFileSize}
+          Placeholder={
+            <Placeholder
+              defaultImage={defaultImage}
+              title={defaultTitle}
+              description={defaultDescription}
+            />
+          }
+          onError={onError}
+          compressImage={compressImage}
+          file={file}
+          setFile={setFile}
+          loading={loading}
+          setLoading={setLoading}
+          progress={progress}
+          loaded={loaded}
+          setLoaded={setLoaded}
+          ref={inputRef}
+          setOpenModal={setOpen}
+        />
+      </div>
+      <AlertModal
+        title="Reemplazo imagen 📷"
+        content={'¿Estás seguro que quieres reemplazar la imagen cargada?'}
+        open={open}
+        setOpen={setOpen}
+        actions={[
+          {
+            text: 'NO',
+            onActionClick: () => setOpen(false),
+          },
+          {
+            text: 'SÍ',
+            onActionClick: clickYesModal,
+            variant: 'contained',
+          },
+        ]}
+      />
+    </>
   );
 };

--- a/src/stories/4-imageloeader.stories.tsx
+++ b/src/stories/4-imageloeader.stories.tsx
@@ -237,7 +237,6 @@ export const Portrait = () => {
     try {
       //Compression
       const compressedFile = await imageCompression(file, options);
-      console.log(compressedFile);
       setLoaded(true);
       setLoading(false);
     } catch (error) {
@@ -394,21 +393,18 @@ export const UploaderWithModal = () => {
   }, [inputRef]);
 
   const clickYesModal = React.useCallback(() => {
-    console.log('You clicked YES');
     openFileLoader();
     setOpen(false);
   }, [openFileLoader, setOpen]);
 
   const handleCustomClick = React.useCallback(() => {
     if (loaded) {
-      console.log('OPEN MODAL!!');
       setOpen(true);
     } else {
       inputRef.current?.click();
     }
   }, [loaded, setOpen]);
 
-  console.log('open: ', open);
   return (
     <>
       <div style={{ width: '300px', height: '400px' }}>


### PR DESCRIPTION
# Description
Se agrega soporte para un modal opcional que se despliega al actualizar una imagen subida. El modal se despliega al hacer click sobre el CardActionArea y sobre el icono de foto.
EDIT: ~~Queda 1 bug pendiente y el tema del forwardRef~~
Se mejora la lógica de los handleClicks.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Storybook

### Screenshots (Only if need)
![image](https://user-images.githubusercontent.com/26127375/105771856-03216d00-5f40-11eb-8401-e7bec7f05faa.png)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules