### PR TITLE
feat: search bar ListitemSkeleton

### DIFF
--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -4,8 +4,8 @@
  * File Created: Tuesday, 1st September 2020 9:46:25 am
  * Author: Luis Aparicio (luis@inventures.cl)
  * -----
- * Last Modified: Monday, 30th November 2020 12:34:26 pm
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Monday, 1st February 2021 10:51:59 am
+ * Modified By: Vicente Melin (vicente@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -31,6 +31,7 @@ import Collapse from '@material-ui/core/Collapse';
 import Fade from '@material-ui/core/Fade';
 import Typography from '@material-ui/core/Typography';
 import { SvgIconComponent } from '@material-ui/icons';
+import { Skeleton } from '@material-ui/lab';
 
 type SearchBarProps = {
   className?: string;
@@ -92,6 +93,10 @@ const useStyles = makeStyles(() =>
     },
     searchIcon: {
       fill: (props: BarStyleProps) => props.iconColor,
+    },
+    listitemSkeleton: {
+      maxWidth: 200,
+      minWidth: 100,
     },
   }),
 );
@@ -164,12 +169,14 @@ export const SearchBar = ({
 type SearchElementItemProps = {
   value: string;
   onSuggestedClick?: (value: string) => void;
-  onClick: () => void;
+  onClick?: () => void;
+  loading?: boolean;
 };
 export const SearchElementItem = ({
   value,
   onSuggestedClick,
   onClick,
+  loading,
 }: SearchElementItemProps) => {
   const classes = useStyles({}); //Must recieve empty object due to BarStyleProps
   const handleSuggestedOnClick = useCallback(() => {
@@ -187,7 +194,15 @@ export const SearchElementItem = ({
           color="textSecondary"
           component="p"
         >
-          {value}
+          {loading ? (
+            <Skeleton
+              variant="text"
+              width={'30vw'}
+              className={classes.listitemSkeleton}
+            />
+          ) : (
+            value
+          )}
         </Typography>
         {!!onSuggestedClick && (
           <ListItemSecondaryAction>

--- a/src/stories/3-SearchBar.stories.tsx
+++ b/src/stories/3-SearchBar.stories.tsx
@@ -4,8 +4,8 @@
  * File Created: Tuesday, 1st September 2020 9:46:25 am
  * Author: Luis Aparicio (luis@inventures.cl)
  * -----
- * Last Modified: Wednesday, 7th October 2020 12:14:59 pm
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Monday, 1st February 2021 10:42:33 am
+ * Modified By: Vicente Melin (vicente@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -246,6 +246,9 @@ export const SearchBarResultFunction = () => {
           value={searchValue}
           onClick={() => handleResultClick(searchValue)}
         />
+      )}
+      {!!searchValue && showResults && searchResults.length == 0 && (
+        <SearchElementItem value={searchValue} loading />
       )}
       {showResults &&
         searchResults


### PR DESCRIPTION
# Description

Add the loading prop to the SearchElementItem component so it shows an skeleton text when its loading.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New component (non-breaking change which adds component a functionality)
- [ ] New hook (non-breaking change which adds hook)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (repo config)
- [ ] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)

![image](https://user-images.githubusercontent.com/37168631/106468269-76fdd100-647c-11eb-9c57-d6bf3332f454.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
