### PR TITLE
fix: clp currency formatter fix

### DIFF
--- a/src/formatters/CurrencyFormatter.ts
+++ b/src/formatters/CurrencyFormatter.ts
@@ -4,7 +4,7 @@
  * File Created: Monday, 31st August 2020 6:08:15 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Monday, 1st February 2021 11:21:15 am
+ * Last Modified: Monday, 1st February 2021 11:30:29 am
  * Modified By: Vicente Melin (vicente@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -18,10 +18,7 @@ import { Formatter } from './Formatter';
 export class CurrencyFormatter extends Formatter {
   format(input: number) {
     return (
-      '$ ' +
-      input
-        .toFixed(0) // always zero decimal digits
-        .replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1.') //separate every 3 digits and use . to separate
+      '$ ' + String(input.toFixed(0)).replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1.') //separate every 3 digits and use . to separate
     );
   }
 }

--- a/src/formatters/CurrencyFormatter.ts
+++ b/src/formatters/CurrencyFormatter.ts
@@ -4,8 +4,8 @@
  * File Created: Monday, 31st August 2020 6:08:15 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 4th November 2020 1:00:07 pm
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Monday, 1st February 2021 11:21:15 am
+ * Modified By: Vicente Melin (vicente@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -17,13 +17,11 @@ import { Formatter } from './Formatter';
 
 export class CurrencyFormatter extends Formatter {
   format(input: number) {
-    const formatter = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    });
-    const formattedText = formatter.format(input);
-    return formattedText.replace(/,/g, '.');
+    return (
+      '$ ' +
+      input
+        .toFixed(0) // always zero decimal digits
+        .replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1.') //separate every 3 digits and use . to separate
+    );
   }
 }


### PR DESCRIPTION
# Description

Change the CLP currency formatter so it uses a regular expression to format the number with a hardcoded $ symbol.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New component (non-breaking change which adds component)
- [ ] New hook (non-breaking change which adds hook)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (repo config)
- [ ] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Storybook
- [ ] Unit testing

### Screenshots (Only if need)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules
