### PR TITLE
fix: optional changes on product details and alert modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,8 +4,8 @@
  * File Created: Wednesday, 23rd September 2020 4:10:47 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Monday, 1st February 2021 10:51:19 am
- * Modified By: Luis Aparicio (luis@inventures.cl)
+ * Last Modified: Tuesday, 9th February 2021 11:07:28 am
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -31,6 +31,9 @@ type ModalProps = {
   setOpen: (open: boolean) => void;
   onClose?: () => void;
   actions?: ActionType[];
+  disableBackdropClick?: boolean;
+  disableEscapeKeyDown?: boolean;
+  onBackdropClick?: () => void;
 };
 
 type ActionType = {
@@ -50,7 +53,17 @@ const useStyles = makeStyles({
 });
 
 export function AlertModal(props: ModalProps) {
-  const { title, open, content, actions, setOpen, onClose } = props;
+  const {
+    title,
+    open,
+    content,
+    actions,
+    setOpen,
+    onClose,
+    disableBackdropClick,
+    disableEscapeKeyDown,
+    onBackdropClick, 
+  } = props;
   const classes = useStyles();
 
   return (
@@ -62,6 +75,9 @@ export function AlertModal(props: ModalProps) {
           setOpen(false);
         }}
         PaperProps={{ className: classes.margin }}
+        disableBackdropClick={disableBackdropClick}
+        disableEscapeKeyDown={disableEscapeKeyDown}
+        onBackdropClick={onBackdropClick}
       >
         <DialogTitle>{title}</DialogTitle>
         <DialogContent>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -62,7 +62,7 @@ export function AlertModal(props: ModalProps) {
     onClose,
     disableBackdropClick,
     disableEscapeKeyDown,
-    onBackdropClick, 
+    onBackdropClick,
   } = props;
   const classes = useStyles();
 

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -95,7 +95,12 @@ export function ProductDetails(props: ProductDetailsProps) {
 
   return (
     <Box className={classes.root}>
-      <CardMedia className={classes.media} image={imageUrl} component="img" onClick={onClickImage}/>
+      <CardMedia
+        className={classes.media}
+        image={imageUrl}
+        component="img"
+        onClick={onClickImage}
+      />
       <Chip
         color="primary"
         size="small"

--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -4,7 +4,7 @@
  * File Created: Friday, 11th September 2020 10:18:53 am
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Monday, 28th September 2020 6:36:41 pm
+ * Last Modified: Tuesday, 9th February 2021 10:58:40 am
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -33,6 +33,7 @@ type ProductDetailsProps = {
   tagIcon?: React.ReactElement;
   description?: string;
   pricePerUnit?: string;
+  onClickImage?: () => void;
   price: number;
 };
 
@@ -53,6 +54,7 @@ const useStyles = makeStyles({
   media: {
     height: '144px',
     objectFit: 'contain',
+    cursor: 'pointer',
   },
   tag: {
     marginTop: '-14px',
@@ -83,6 +85,7 @@ export function ProductDetails(props: ProductDetailsProps) {
     tagIcon,
     price,
     description,
+    onClickImage,
     pricePerUnit,
   } = props;
 
@@ -92,7 +95,7 @@ export function ProductDetails(props: ProductDetailsProps) {
 
   return (
     <Box className={classes.root}>
-      <CardMedia className={classes.media} image={imageUrl} component="img" />
+      <CardMedia className={classes.media} image={imageUrl} component="img" onClick={onClickImage}/>
       <Chip
         color="primary"
         size="small"

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,8 +4,8 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Friday, 29th January 2021 10:12:45 am
- * Modified By: Vicente Melin (vicente@inventures.cl)
+ * Last Modified: Tuesday, 9th February 2021 10:57:08 am
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -21,8 +21,9 @@ import {
   ProductDetails,
 } from '../components';
 import InsertDriveFileOutlinedIcon from '@material-ui/icons/InsertDriveFileOutlined';
-import { Skeleton } from '@material-ui/lab';
+import { Alert, Skeleton } from '@material-ui/lab';
 import { text, number } from '@storybook/addon-knobs';
+import { Console } from 'console';
 
 export default {
   title: 'Card',
@@ -293,6 +294,7 @@ export const ProductDetailsCard = () => {
         price={15813}
         tagText={'Receta simple'}
         tagIcon={<InsertDriveFileOutlinedIcon />}
+        onClickImage={()=> console.log('You clicked the product details image!')}
         pricePerUnit="$527 /comprimido"
       />
     </>

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Tuesday, 9th February 2021 10:57:08 am
+ * Last Modified: Tuesday, 9th February 2021 11:21:48 am
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -21,9 +21,8 @@ import {
   ProductDetails,
 } from '../components';
 import InsertDriveFileOutlinedIcon from '@material-ui/icons/InsertDriveFileOutlined';
-import { Alert, Skeleton } from '@material-ui/lab';
+import { Skeleton } from '@material-ui/lab';
 import { text, number } from '@storybook/addon-knobs';
-import { Console } from 'console';
 
 export default {
   title: 'Card',
@@ -294,7 +293,9 @@ export const ProductDetailsCard = () => {
         price={15813}
         tagText={'Receta simple'}
         tagIcon={<InsertDriveFileOutlinedIcon />}
-        onClickImage={()=> console.log('You clicked the product details image!')}
+        onClickImage={() =>
+          console.log('You clicked the product details image!')
+        }
         pricePerUnit="$527 /comprimido"
       />
     </>

--- a/src/stories/5-Modal.stories.tsx
+++ b/src/stories/5-Modal.stories.tsx
@@ -4,8 +4,8 @@
  * File Created: Wednesday, 23rd September 2020 4:11:55 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Monday, 1st February 2021 11:23:06 am
- * Modified By: Luis Aparicio (luis@inventures.cl)
+ * Last Modified: Tuesday, 9th February 2021 11:11:09 am
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -13,7 +13,7 @@
  * Inventures - www.inventures.cl
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { AlertModal } from '../components';
 import Button from '@material-ui/core/Button';
 import { text } from '@storybook/addon-knobs';
@@ -87,6 +87,8 @@ export const CustomModalWithOnCloseBehavior = () => {
         open={open}
         setOpen={setOpen}
         onClose={handleOnClose}
+        disableBackdropClick={true}
+        disableEscapeKeyDown={true}
         actions={[
           {
             text: 'OK',


### PR DESCRIPTION
# Description
Changes for `ProductDetails` component:
- new optional prop `onClickImage` to make the image clickable

Changes for `AlertModal` component:
- new optional prop `disableBackdropClick`: boolean. If true, clicking the backdrop will not fire the `onClose` callback. 
- new optional prop `disableEscapeKeyDown`: boolean. If true, clicking the backdrop will not fire the `onClose` callback. 
- new optional prop  `onBackdropClick`: function. Callback fired when the backdrop is clicked.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Storybook

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules