### PR TITLE
fix: warning on alert modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -4,7 +4,7 @@
  * File Created: Wednesday, 23rd September 2020 4:10:47 pm
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Tuesday, 9th February 2021 4:14:29 pm
+ * Last Modified: Thursday, 25th February 2021 6:20:06 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -63,13 +63,14 @@ export function AlertModal(props: ModalProps) {
     disableBackdropClick,
     disableEscapeKeyDown,
     onBackdropClick,
+    ...otherProps
   } = props;
   const classes = useStyles();
 
   return (
     <div>
       <Dialog
-        {...props}
+        {...otherProps}
         open={open}
         onClose={() => {
           onClose?.();


### PR DESCRIPTION
# Description
Fixes small DOM warning regarding incorrect spread of props on Alert Modal

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Storybook
- [ ] Unit testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules