### PR TITLE
feat: no wrap for product list

### DIFF
--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -4,8 +4,8 @@
  * File Created: Friday, 11th September 2020 10:18:24 am
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Friday, 29th January 2021 10:07:17 am
- * Modified By: Vicente Melin (vicente@inventures.cl)
+ * Last Modified: Monday, 26th April 2021 6:23:52 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -13,14 +13,18 @@
  * Inventures - www.inventures.cl
  */
 import React from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import { ProductPropTypes, ProductCard } from './ProductCard';
 import { ProductCardSkeleton } from './ProductCardSkeleton';
+import { Theme, createStyles } from '@material-ui/core/styles';
+import GridList from '@material-ui/core/GridList';
+import GridListTile from '@material-ui/core/GridListTile';
 
 type ProductList = {
   products: ProductPropTypes[];
   gridBreakpoints: GridBreakpoints;
   loading?: boolean;
+  wrap?: boolean;
 };
 type GridBreakpoints = {
   xs:
@@ -105,6 +109,23 @@ type GridBreakpoints = {
     | undefined;
 };
 
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'space-around',
+      backgroundColor: theme.palette.background.paper,
+    },
+    gridList: {
+      flexWrap: 'nowrap',
+    },
+    customTiles: {
+      height: '100%',
+    },
+  }),
+);
+
 export function ProductList(props: ProductList) {
   /**
    * Returns the a product card list component, which uses ProductCard component
@@ -119,7 +140,46 @@ export function ProductList(props: ProductList) {
     products,
     gridBreakpoints: { xs = 6, sm = 4, md = 3, lg = 2, xl = 1 } = {},
     loading,
+    wrap,
   } = props;
+  const classes = useStyles();
+
+  if (!wrap) {
+    return (
+      <div className={classes.root}>
+        <GridList
+          className={classes.gridList}
+          cols={2.3}
+          cellHeight={270}
+          classes={{ root: classes.customTiles }}
+          spacing={8}
+        >
+          {products.map((cardInfo: ProductPropTypes, index: number) => (
+            <GridListTile
+              key={cardInfo.title + index.toString()}
+              classes={{ root: classes.customTiles }}
+            >
+              <ProductCard
+                imageUrl={cardInfo.imageUrl}
+                title={cardInfo.title}
+                subtitle={cardInfo.subtitle}
+                details={cardInfo.details}
+                description={cardInfo.description}
+                price={cardInfo.price}
+                tagText={cardInfo.tagText}
+                tagIcon={cardInfo.tagIcon}
+                onClickCard={cardInfo.onClickCard}
+                badgeContent={cardInfo.badgeContent}
+                badgeColor={cardInfo.badgeColor}
+                badgeTextColor={cardInfo.badgeTextColor}
+              />
+            </GridListTile>
+          ))}
+        </GridList>
+      </div>
+    );
+  }
+
   return (
     <Grid container spacing={1}>
       {products.map((cardInfo: ProductPropTypes, index: number) => (

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,7 +4,7 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Tuesday, 9th February 2021 4:20:28 pm
+ * Last Modified: Monday, 26th April 2021 5:59:38 pm
  * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
@@ -63,6 +63,114 @@ export const EditableCard = () => {
   );
 };
 
+export const ProductCarouselNoWrap = () => {
+  return (
+    <>
+      <ProductListHeader
+        title={'Más vendidos'}
+        onClickCarousel={() =>
+          window.alert('Want to know more about the carousel products?')
+        }
+      />
+
+      <ProductList
+        loading={false}
+        products={[
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornillafornillafornillafornillafornillafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            price: 15990,
+            tagText: 'Receta retenida',
+            tagIcon: <InsertDriveFileOutlinedIcon />,
+            badgeContent: 5,
+            badgeColor: 'red',
+            badgeTextColor: '#FFFFFF',
+            onClickCard: () => console.log('You clicked B1!'),
+          },
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            badgeContent: 5,
+            badgeColor: 'red',
+            badgeTextColor: '#FFFFFF',
+            onClickCard: () => console.log('You clicked B2!'),
+          },
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            description: '500 mg',
+            price: 15990,
+            tagText: 'Receta retenida',
+            tagIcon: <InsertDriveFileOutlinedIcon />,
+            onClickCard: () => console.log('You clicked B3!'),
+          },
+
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            badgeContent: 5,
+            badgeColor: 'red',
+            badgeTextColor: '#FFFFFF',
+            onClickCard: () => console.log('You clicked B2!'),
+          },
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            tagText: 'Receta retenida',
+            tagIcon: <InsertDriveFileOutlinedIcon />,
+            onClickCard: () => console.log('You clicked B3!'),
+          },
+
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            onClickCard: () => console.log('You clicked B2!'),
+          },
+          {
+            imageUrl:
+              'https://www.cruzverde.cl/dw/image/v2/BDPM_PRD/on/demandware.static/-/Sites-masterCatalog_Chile/default/dw0ebcdb64/images/large/296432-okrafit-120-capsulas.jpg?sw=1000&sh=1000',
+            title: 'Glafornil',
+            subtitle: 'Metformina Clorhidrato Clorhidrato',
+            details: '30 comprimidos recubiertos',
+            description: '500 mg',
+            price: 15990,
+            tagText: 'Receta retenida',
+            tagIcon: <InsertDriveFileOutlinedIcon />,
+            badgeContent: 10,
+            badgeColor: 'blue',
+            badgeTextColor: 'white',
+            onClickCard: () => console.log('You clicked B3!'),
+          },
+        ]}
+        gridBreakpoints={{ xs: 6, sm: 4, md: 3, lg: 2, xl: 1 }}
+      />
+    </>
+  );
+};
+
 export const ProductCarousel = () => {
   return (
     <>
@@ -75,6 +183,7 @@ export const ProductCarousel = () => {
 
       <ProductList
         loading={false}
+        wrap
         products={[
           {
             imageUrl:


### PR DESCRIPTION
# Description
Se agrega la prop wrap a ProductList, para manejar un scroll horizontal opcional.
- `wrap={false}`:  se mostrará un gridList de una línea, con scroll horizontal
- `wrap={true}`: se mostrará el grid de product cards de forma normal, igual que anteriormente

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- [x] Storybook

### Screenshots (Only if need)

https://user-images.githubusercontent.com/26127375/116159385-246c3380-a6be-11eb-9f9c-c476e3b1d6fe.mov


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules