### PR TITLE
refactor: changed tag management on product details

### DIFF
--- a/src/components/ProductDetails.tsx
+++ b/src/components/ProductDetails.tsx
@@ -4,8 +4,8 @@
  * File Created: Friday, 11th September 2020 10:18:53 am
  * Author: Esperanza Horn (esperanza@inventures.cl)
  * -----
- * Last Modified: Wednesday, 28th April 2021 5:38:28 pm
- * Modified By: Luis Aparicio (luis@inventures.cl)
+ * Last Modified: Tuesday, 11th May 2021 6:28:43 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2020 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -15,25 +15,9 @@
 
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import {
-  CardMedia,
-  CardContent,
-  Typography,
-  Chip,
-  Box,
-} from '@material-ui/core';
+import { CardMedia, CardContent, Typography, Box } from '@material-ui/core';
 import { CurrencyFormatter } from '../formatters';
 import clsx from 'clsx';
-
-type TagClassStyle = {
-  style: string;
-};
-
-type Tag = {
-  icon?: React.ReactElement;
-  text: string;
-  class?: TagClassStyle;
-};
 
 type ClassesProps = {
   chip?: string;
@@ -44,13 +28,11 @@ type ProductDetailsProps = {
   imageUrl?: string;
   title: string;
   subtitle?: string;
-  tagText?: string;
-  tagIcon?: React.ReactElement;
   description?: string;
   pricePerUnit?: string;
   onClickImage?: () => void;
   price: number;
-  extraTags?: Tag[];
+  tags?: React.ReactElement[];
   classes?: ClassesProps;
 };
 
@@ -86,6 +68,8 @@ const useStyles = makeStyles({
   },
   tagsDiv: {
     marginTop: -14,
+    display: 'flex',
+    flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'baseline',
   },
@@ -104,13 +88,11 @@ export function ProductDetails(props: ProductDetailsProps) {
     imageUrl,
     title,
     subtitle,
-    tagText,
-    tagIcon,
     price,
     description,
     onClickImage,
     pricePerUnit,
-    extraTags,
+    tags,
     classes: propClasses,
   } = props;
 
@@ -128,27 +110,8 @@ export function ProductDetails(props: ProductDetailsProps) {
       />
 
       <div className={clsx(classes.tagsDiv, propClasses?.tagsDiv)}>
-        {tagText && (
-          <Chip
-            color="primary"
-            size="small"
-            icon={tagIcon}
-            label={tagText}
-            className={clsx(classes.tag, propClasses?.chip)}
-          />
-        )}
-
-        {extraTags?.map((tag: Tag, i: number) => {
-          return (
-            <Chip
-              key={`extraTag-${i}`}
-              color="primary"
-              size="small"
-              icon={tag.icon}
-              label={tag.text}
-              className={clsx(classes.tag, tag.class?.style)}
-            />
-          );
+        {tags?.map((tag, index: number) => {
+          return <div key={`tag-${index}`}>{tag}</div>;
         })}
       </div>
 

--- a/src/stories/2-card.stories.tsx
+++ b/src/stories/2-card.stories.tsx
@@ -4,8 +4,8 @@
  * File Created: Tuesday, 4th August 2020 5:47:50 pm
  * Author: Gabriel Ulloa (gabriel@inventures.cl)
  * -----
- * Last Modified: Monday, 3rd May 2021 11:09:53 pm
- * Modified By: Gabriel Ulloa (gabriel@inventures.cl)
+ * Last Modified: Tuesday, 11th May 2021 6:28:20 pm
+ * Modified By: Esperanza Horn (esperanza@inventures.cl)
  * -----
  * Copyright 2019 - 2020 Incrementa Ventures SpA. ALL RIGHTS RESERVED
  * Terms and conditions defined in license.txt
@@ -25,7 +25,7 @@ import LocalPharmacyRoundedIcon from '@material-ui/icons/LocalPharmacyRounded';
 import WarningRoundedIcon from '@material-ui/icons/WarningRounded';
 import { Skeleton } from '@material-ui/lab';
 import { text, number } from '@storybook/addon-knobs';
-import { createStyles, makeStyles, Typography } from '@material-ui/core';
+import { createStyles, makeStyles, Typography, Chip } from '@material-ui/core';
 
 export default {
   title: 'Card',
@@ -475,8 +475,15 @@ export const ProductDetailsCard = () => {
         subtitle={text2}
         description={text3}
         price={15813}
-        // tagText={'Receta simple'}
-        tagIcon={<InsertDriveFileOutlinedIcon />}
+        tags={[
+          <Chip
+            color="primary"
+            key="1"
+            size="small"
+            icon={<InsertDriveFileOutlinedIcon />}
+            label={'Receta simple'}
+          />,
+        ]}
         onClickImage={() =>
           console.log('You clicked the product details image!')
         }
@@ -496,21 +503,30 @@ export const ProductDetailsCardExtraTags = () => {
   const text2 = text('Segundo texto', 'Sertralina • 100mg');
   const text3 = text('Tercero texto', '30 comprimidos • Andrómaco');
   const tags = [
-    {
-      text: 'Receta Cheque',
-      icon: <InsertDriveFileOutlinedIcon />,
-      class: { style: classes.prescriptionTag },
-    },
-    {
-      text: 'Bioequivalentes',
-      icon: <InsertDriveFileOutlinedIcon />,
-      class: { style: classes.bioequivalentTag },
-    },
-    {
-      text: 'Another',
-      icon: <InsertDriveFileOutlinedIcon />,
-      class: { style: classes.bioequivalentTag },
-    },
+    <Chip
+      color="primary"
+      key="1"
+      size="small"
+      icon={<InsertDriveFileOutlinedIcon />}
+      className={classes.prescriptionTag}
+      label={'Receta Cheque'}
+    />,
+    <Chip
+      color="primary"
+      key="1"
+      size="small"
+      icon={<InsertDriveFileOutlinedIcon />}
+      className={classes.bioequivalentTag}
+      label={'Bioequivalentes'}
+    />,
+    <Chip
+      color="primary"
+      key="1"
+      size="small"
+      icon={<InsertDriveFileOutlinedIcon />}
+      className={classes.bioequivalentTag}
+      label={'Another'}
+    />,
   ];
 
   return (
@@ -521,14 +537,12 @@ export const ProductDetailsCardExtraTags = () => {
         subtitle={text2}
         description={text3}
         price={15813}
-        tagText={'Receta simple'}
-        tagIcon={<InsertDriveFileOutlinedIcon />}
-        extraTags={tags}
+        tags={tags}
         onClickImage={() =>
           console.log('You clicked the product details image!')
         }
         pricePerUnit="$527 /comprimido"
-        classes={{ chip: classes.chip, tagsDiv: classes.tagsDiv }}
+        classes={{ chip: classes.chip }}
       />
     </>
   );
@@ -544,15 +558,14 @@ const useStyles = makeStyles(() =>
       backgroundColor: '#ffe512',
       color: 'red',
       height: 21,
+      margin: '2px',
     },
     prescriptionTag: {
+      margin: '2px',
       height: 21,
     },
     chip: {
       height: 21,
-    },
-    tagsDiv: {
-      marginTop: 0,
     },
     badge: {
       backgroundColor: 'green',


### PR DESCRIPTION
# Description
###  💥⚠️ BREAKING GHANGE ⚠️💥
This PR changes the way tags are managed on the `ProductDetails` component.
_BEFORE_:
- The component received a `tagText`, `tagIcon`, and `extraTags` props.
- Tags were internally turned into material-UI chips
- Tags received an optional `classes` prop for style customization

_NOW_:
- The props `tagText`, `tagIcon`, and `extraTags` have been removed
- There is a new, single prop called `tags` that receives an a array of `React.ReactElement`s. 
- Tags can now be any component the user desires. This change will help tag customization for the user.
- Each style can be customized accordingly, before being passed into the array

Examples with a single tag and several tags have been provided in the screenshots below, and in the Card Stories.

## Type of change
- Refactor
- Breaking Change 💥

## How Has This Been Tested?
- [x] Storybook

### Screenshots (Only if need)
SINGLE TAG:
<img width="779" alt="Screen Shot 2021-05-11 at 18 29 05" src="https://user-images.githubusercontent.com/26127375/117893391-4c47c380-b288-11eb-920e-ba3643ca9efb.png">

MANY TAGS:
<img width="778" alt="Screen Shot 2021-05-11 at 18 28 58" src="https://user-images.githubusercontent.com/26127375/117892810-61702280-b287-11eb-8b8c-cb9c9d7eb1b8.png">

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The target of this commit is 'dev'
- [x] Any dependent changes have been merged and published in downstream modules